### PR TITLE
some initial Debian packaging updates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-com.github.rajsolai.textsnatcher (1.0.0) RELEASED; urgency=high
+com.github.rajsolai.textsnatcher (1.0.0) UNRELEASED; urgency=medium
 
-  * Initial Release * 
+  * Initial Release.
 
- -- solairaj <solairaj@solairaj-ideapad>  Mon 31 Jan 2022 10:35:12 +0530
+ -- solairaj <solairaj@gmail.com>  Mon, 31 Jan 2022 10:35:12 +0530

--- a/debian/control
+++ b/debian/control
@@ -1,16 +1,28 @@
 Source: com.github.rajsolai.textsnatcher
-Section: unknown
+Section: utils
 Priority: optional
-Maintainer: Solai Raj <solairaj@gmail.com> github.com/RajSolai
-Build-Depends: debhelper-compat (= 12)
+Maintainer: Solai Raj <solairaj@gmail.com>
+Build-Depends: debhelper-compat (= 12),
+ 		 		 		 		 		meson,
+               valac,
+               libglib2.0-dev,
+               libgtk-3-dev,
+               libgranite-dev,
+               libhandy-1-dev,
+               libgdk-pixbuf-2.0-dev,
+               libgirepository1.0-dev,
+               libportal-dev
 Standards-Version: 4.4.1
 Homepage: https://github.com/RajSolai/TextSnatcher
-#Vcs-Browser: https://salsa.debian.org/debian/com.github.rajsolai.textsnatcher
-#Vcs-Git: https://salsa.debian.org/debian/com.github.rajsolai.textsnatcher.git
+Vcs-Browser: https://github.com/RajSolai/TextSnatcher
+Vcs-Git: https://github.com/RajSolai/TextSnatcher.git
 
 Package: com.github.rajsolai.textsnatcher
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends},
+         tesseract-ocr (>= 4.0.0),
+         tessdata-best (>= 4.0)
+Recommends: tesseract-ocr-all
 Description: Snatch Text with just a Drag
  Multiple Language Support.
  Copy Text from images with a Drag.

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,7 +5,6 @@ Source: https://github.com/RajSolai/TextSnatcher
 
 Files: *
 Copyright: 2022 Solai Raj <solairaj@gmail.com>
-           <years> <likewise for another author>
 License: GPL-3
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,26 +1,15 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: com.github.rajsolai.textsnatcher
-Upstream-Contact: <preferred name and address to reach the upstream project>
-Source: <url://example.com>
+Upstream-Contact: Solai Raj <solairaj@gmail.com>
+Source: https://github.com/RajSolai/TextSnatcher
 
 Files: *
-Copyright: <years> <put author's name and email here>
+Copyright: 2022 Solai Raj <solairaj@gmail.com>
            <years> <likewise for another author>
-License: <special license>
- <Put the license of the package here indented by 1 space>
- <This follows the format of Description: lines in control file>
- .
- <Including paragraphs>
-
-# If you want to use GPL v2 or later for the /debian/* files use
-# the following clauses, or change it to suit. Delete these two lines
-Files: debian/*
-Copyright: 2022 Solai Raj <solairaj@unknown>
-License: GPL-2+
- This package is free software; you can redistribute it and/or modify
+License: GPL-3
+ This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
- (at your option) any later version.
+ the Free Software Foundation, version 3.
  .
  This package is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -28,16 +17,7 @@ License: GPL-2+
  GNU General Public License for more details.
  .
  You should have received a copy of the GNU General Public License
- along with this program. If not, see <https://www.gnu.org/licenses/>
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
  .
  On Debian systems, the complete text of the GNU General
- Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.
-# Please avoid picking licenses with terms that are more restrictive than the
-# packaged work, as it may make Debian's contributions unacceptable upstream.
-#
-# If you need, there are some extra license texts available in two places:
-#   /usr/share/debhelper/dh_make/licenses/
-#   /usr/share/common-licenses/
+ Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".


### PR DESCRIPTION
- update build and runtime depends, other minor fixes
- - change distribution value to "UNRELEASED" (Note: UNRELEASED and unstable until it is packaged in Debian or other distribution repo.)
- change urgency to medium - this is not a critical release
- fix dpkg-genchanges warning
- correct copyright file - license used is GPL-3, but the debian/copyright file had all files with an null copyright, and the debian/* files as GPL-2.