### PR TITLE
Spanish button error and path with spaces.

### DIFF
--- a/src/components/LanguageButton.vala
+++ b/src/components/LanguageButton.vala
@@ -45,6 +45,7 @@ public class LanguageButton : Gtk.MenuButton {
         ind.clicked.connect (() => { lang.save_pref_language ("ind") ; }) ;
 
         menu_list.add (eng) ;
+        menu_list.add (spa) ;
         menu_list.add (chi_sim) ;
         menu_list.add (jpn) ;
         menu_list.add (nld) ;

--- a/src/services/TesseractTrigger.vala
+++ b/src/services/TesseractTrigger.vala
@@ -58,7 +58,7 @@ class TesseractTrigger : Object {
         Idle.add (read_image.callback) ;
         yield ;
         try {
-            string tess_command = "tesseract " + file_path + " " + out_path + @" -l $lang" ;
+            string tess_command = "tesseract '" + file_path + "' '" + out_path + "'" + @" -l $lang" ;
             Process.spawn_command_line_sync (tess_command, out res, out err, out stat) ;
             if (stat == 0) {
                 copy_to_clipboard () ;


### PR DESCRIPTION
Hello.

I make two simples changes.

1. Add to menulist the spa button. This button is created but not add in the menulist.
2. When the paths have spaces, the cmd generate a error. I put a simple ' for fixed this bug.

